### PR TITLE
Fix node ID mismatch in consignment

### DIFF
--- a/src/stashd/stash.rs
+++ b/src/stashd/stash.rs
@@ -120,15 +120,11 @@ impl Stash for Runtime {
         if let Some(transition) =
             node.as_any().downcast_ref::<Transition>().clone()
         {
-            let mut transition = transition.clone();
-            transition.conceal_except(&expose);
             let anchor = anchor.ok_or(Error::AnchorParameterIsRequired)?;
             state_transitions.push((anchor.clone(), transition.clone()));
         } else if let Some(extension) =
             node.as_any().downcast_ref::<Extension>().clone()
         {
-            let mut extension = extension.clone();
-            extension.conceal_except(&expose);
             state_extensions.push(extension.clone());
         } else {
             Err(Error::GenesisNode)?;


### PR DESCRIPTION
This is a proposed fix for an issue that I have bumped into when testing the `fungible validate` command, and that had been reported at #130.

It turns out that the way the Consignment structure was being generated, it ended up with state transition node IDs referenced by different fields of the structure that did not match. More specifically, the state transition node IDs in the `endpoints` field did not match the state transition node IDs in the `state_transitions` field.

This happened because the state transition (in my test case there was a single state transition) had some of its assignments concealed before it was added to the `state_transitions` field but was used as it was in the `endpoints` field. The modification of the state transition (via the concealment of its assignments) caused its node ID to change, leading to the mismatch.

The proposed fix makes sure that the state transitions are modified as needed (have some of its assignments concealed) before they are assigned to any of the Consignment fields. That way the whole Consignment structure will reference the modified state transitions, avoiding the mismatch. That same scheme is also applied to state extensions.