### PR TITLE
Properly handle result from 'validate' request to Stash daemon

### DIFF
--- a/src/fungibled/runtime.rs
+++ b/src/fungibled/runtime.rs
@@ -272,8 +272,7 @@ impl Runtime {
         consignment: &Consignment,
     ) -> Result<Reply, ServiceErrorDomain> {
         debug!("Got VALIDATE");
-        self.validate(consignment.clone())?;
-        Ok(Reply::Success)
+        self.validate(consignment.clone())
     }
 
     fn rpc_accept(
@@ -389,7 +388,7 @@ impl Runtime {
             self.stash_req_rep(rpc::stash::Request::Validate(consignment))?;
 
         match reply {
-            Reply::Success | Reply::Failure(_) => Ok(reply),
+            Reply::ValidationStatus(_) => Ok(reply),
             _ => Err(ServiceErrorDomain::Api(ApiErrorType::UnexpectedReply)),
         }
     }


### PR DESCRIPTION
This fix makes the Fungible daemon to properly handle the result returned from the Stash daemon for a 'validate' request.

It seems that the Fungible daemon has been overlooked when changes have been made (on January 27th) to provide a better reporting for the outcome of the `fungible validate` command.