### PR TITLE
Fix asset 'fractional_bits' error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
  "libsqlite3-sys",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits 0.1.43",
  "uuid",
 ]
 
@@ -1568,7 +1568,7 @@ checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 [[package]]
 name = "rgb-core"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#e5b6c0a0a8149e96009f07a61ec00db420dc8852"
+source = "git+https://github.com/rgb-org/rgb-core#33633a55f8462b9a388b51d1d573a27e8ec55eb7"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "rgb20"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#e5b6c0a0a8149e96009f07a61ec00db420dc8852"
+source = "git+https://github.com/rgb-org/rgb-core#33633a55f8462b9a388b51d1d573a27e8ec55eb7"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "rgb21"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#e5b6c0a0a8149e96009f07a61ec00db420dc8852"
+source = "git+https://github.com/rgb-org/rgb-core#33633a55f8462b9a388b51d1d573a27e8ec55eb7"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -1630,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "rgb22"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#e5b6c0a0a8149e96009f07a61ec00db420dc8852"
+source = "git+https://github.com/rgb-org/rgb-core#33633a55f8462b9a388b51d1d573a27e8ec55eb7"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "rgb23"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#e5b6c0a0a8149e96009f07a61ec00db420dc8852"
+source = "git+https://github.com/rgb-org/rgb-core#33633a55f8462b9a388b51d1d573a27e8ec55eb7"
 dependencies = [
  "amplify",
  "amplify_derive",

--- a/src/fungibled/sql/models.rs
+++ b/src/fungibled/sql/models.rs
@@ -71,7 +71,7 @@ impl SqlAsset {
             is_issued_known: asset.supply().is_issued_known().clone(),
             max_cap: *asset.supply().issue_limit() as i64,
             chain: asset.chain().to_string(),
-            fractional_bits: vec![asset.fractional_bits().clone()],
+            fractional_bits: vec![asset.decimal_precision().clone()],
             asset_date: asset.date().clone(),
         })
     }


### PR DESCRIPTION
If one tries to compile the library using the latest version of the dependency package 'rgb-core', they will get the following error:

```shell
error[E0599]: no method named `fractional_bits` found for reference `&rgb20::Asset` in the current scope
#16 738.3   --> src/fungibled/sql/models.rs:74:41
#16 738.3    |
#16 738.3 74 |             fractional_bits: vec![asset.fractional_bits().clone()],
#16 738.3    |                                         ^^^^^^^^^^^^^^^ method not found in `&rgb20::As
```

This PR fixes it.