### PR TITLE
Fix filename extension of consignment files

### DIFF
--- a/src/cli/fungible.rs
+++ b/src/cli/fungible.rs
@@ -495,9 +495,9 @@ impl TransferCli {
             Reply::Transfer(transfer) => {
                 let mut consignment = transfer.consignment.clone();
                 let mut theirs = self.consignment.clone();
-                theirs.set_extension(".concealed.rgb");
+                theirs.set_extension("concealed.rgb");
                 let mut ours = self.consignment;
-                ours.set_extension(".revealed.rgb");
+                ours.set_extension("revealed.rgb");
                 consignment.write_file(&ours)?;
 
                 let receiver = self.receiver;


### PR DESCRIPTION
The consignment files output by the `fungible transfer` CLI command have filenames that incorrectly include a spurious dot character (`.`) before the `.releaved.rgb` or `.concealed.rgb` extensions. See example below:

```shell
consignment..revealed.rgb
consignment..concealed.rgb
```

This PR fixes it.