### PR TITLE
Transfering from multi-asset outputs: closes #143

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,7 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 [[package]]
 name = "lnp-core"
 version = "0.4.0-alpha.1"
-source = "git+https://github.com/LNP-BP/lnp-core#06e861871851216199f273688d854f2286424520"
+source = "git+https://github.com/LNP-BP/lnp-core#42734c166b37ed9b6ad5b5e902ccf69f8f78a564"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -1003,31 +1003,10 @@ dependencies = [
  "internet2",
  "lazy_static",
  "lightning_encoding",
- "lnpbp 0.4.0 (git+https://github.com/LNP-BP/rust-lnpbp)",
+ "lnpbp",
  "serde 1.0.124",
  "serde_with",
  "strict_encoding",
-]
-
-[[package]]
-name = "lnpbp"
-version = "0.4.0"
-source = "git+https://github.com/LNP-BP/rust-lnpbp#1afc7146044e5c00af40ee4ed4cd3a520c9d0ab5"
-dependencies = [
- "amplify",
- "amplify_derive",
- "bech32",
- "bitcoin",
- "bitcoin_hashes 0.9.4",
- "client_side_validation",
- "deflate",
- "descriptor-wallet",
- "inflate",
- "lazy_static",
- "lightning_encoding",
- "miniscript",
- "strict_encoding",
- "strict_encoding_derive",
 ]
 
 [[package]]
@@ -1594,7 +1573,7 @@ checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 [[package]]
 name = "rgb-core"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#e3a2774eb3577d2f3808d6f919dccb305491d50e"
+source = "git+https://github.com/rgb-org/rgb-core#7efffd7fd42d85a1062f45799c3ca28a58438ec4"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -1610,7 +1589,7 @@ dependencies = [
  "inflate",
  "lazy_static",
  "lightning_encoding",
- "lnpbp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lnpbp",
  "miniscript",
  "num-derive",
  "num-traits 0.2.14",
@@ -1626,13 +1605,13 @@ dependencies = [
 [[package]]
 name = "rgb20"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#e3a2774eb3577d2f3808d6f919dccb305491d50e"
+source = "git+https://github.com/rgb-org/rgb-core#7efffd7fd42d85a1062f45799c3ca28a58438ec4"
 dependencies = [
  "amplify",
  "amplify_derive",
  "bitcoin",
  "chrono",
- "lnpbp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lnpbp",
  "regex",
  "rgb-core",
  "serde 1.0.124",
@@ -1643,39 +1622,39 @@ dependencies = [
 [[package]]
 name = "rgb21"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#e3a2774eb3577d2f3808d6f919dccb305491d50e"
+source = "git+https://github.com/rgb-org/rgb-core#7efffd7fd42d85a1062f45799c3ca28a58438ec4"
 dependencies = [
  "amplify",
  "amplify_derive",
  "bitcoin",
  "chrono",
- "lnpbp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lnpbp",
  "rgb-core",
 ]
 
 [[package]]
 name = "rgb22"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#e3a2774eb3577d2f3808d6f919dccb305491d50e"
+source = "git+https://github.com/rgb-org/rgb-core#7efffd7fd42d85a1062f45799c3ca28a58438ec4"
 dependencies = [
  "amplify",
  "amplify_derive",
  "bitcoin",
  "chrono",
- "lnpbp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lnpbp",
  "rgb-core",
 ]
 
 [[package]]
 name = "rgb23"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#e3a2774eb3577d2f3808d6f919dccb305491d50e"
+source = "git+https://github.com/rgb-org/rgb-core#7efffd7fd42d85a1062f45799c3ca28a58438ec4"
 dependencies = [
  "amplify",
  "amplify_derive",
  "bitcoin",
  "chrono",
- "lnpbp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lnpbp",
  "rgb-core",
 ]
 
@@ -1701,7 +1680,7 @@ dependencies = [
  "hammersbald",
  "internet2",
  "lazy_static",
- "lnpbp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lnpbp",
  "log",
  "microservices",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "amplify"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92856ad516a7ada2b2e5ce047c3dc5ea0c69f9a053823e3feb1c67289ac5ee3"
+checksum = "6cd7d8887f771c295502e7d5c5c7ee130b794f65af92f3176f22a762587b03d3"
 dependencies = [
  "amplify_derive",
  "parse_arg",
@@ -43,13 +43,13 @@ dependencies = [
 
 [[package]]
 name = "amplify_derive"
-version = "2.4.4"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cc50fd13f783af1129d1c7bdaa9a54a56cf9bd7697ee3609497bf7968daff3"
+checksum = "f24ae6c0675ea6f01a58c57eb05967d91f22740170ff9951fa7fc45a6c6e9b76"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -59,7 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9076b2ac55f9451a0b7f36921d1c7d3a4c8822c3cbf6ecb5eece6fab90c7fc22"
 dependencies = [
  "proc-macro2 1.0.24",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -216,9 +216,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -319,7 +319,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -448,7 +448,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "strsim 0.9.3",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -459,7 +459,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -531,7 +531,7 @@ checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -859,7 +859,7 @@ dependencies = [
  "amplify",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -972,7 +972,7 @@ dependencies = [
  "amplify_derive_helpers",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -1154,7 +1154,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -1211,15 +1211,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.32"
+version = "0.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -1234,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.60"
+version = "0.9.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -1260,9 +1260,9 @@ checksum = "14248cc8eced350e20122a291613de29e4fa129ba2731818c4cdbb44fccd3e55"
 
 [[package]]
 name = "paste"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "percent-encoding"
@@ -1307,7 +1307,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
  "version_check",
 ]
 
@@ -1554,26 +1554,58 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "rgb-core"
-version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#7efffd7fd42d85a1062f45799c3ca28a58438ec4"
+version = "0.4.0"
+source = "git+https://github.com/rgb-org/rgb-core#41f23e3625bc6671bc804ed6ad085f7304e6ed17"
+dependencies = [
+ "amplify",
+ "amplify_derive",
+ "bech32",
+ "bitcoin",
+ "bitcoin_hashes 0.9.4",
+ "chrono",
+ "clap",
+ "deflate",
+ "descriptor-wallet",
+ "ed25519-dalek",
+ "grin_secp256k1zkp",
+ "inflate",
+ "lazy_static",
+ "lightning_encoding",
+ "lnpbp",
+ "miniscript",
+ "num-derive",
+ "num-traits 0.2.14",
+ "regex",
+ "serde 1.0.124",
+ "serde_json",
+ "serde_with",
+ "serde_with_macros",
+ "serde_yaml",
+ "strict_encoding",
+]
+
+[[package]]
+name = "rgb-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd9bd2df39de07815c1693da099f99058b3cae0fe7a5df31559ac9d5c1b97439"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -1604,8 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "rgb20"
-version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#7efffd7fd42d85a1062f45799c3ca28a58438ec4"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "554fe61daf0a7a1763c51111f33bbb100b6abdf482d543a20927f139a031eda0"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -1613,7 +1646,7 @@ dependencies = [
  "chrono",
  "lnpbp",
  "regex",
- "rgb-core",
+ "rgb-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.124",
  "serde_with",
  "url",
@@ -1622,40 +1655,40 @@ dependencies = [
 [[package]]
 name = "rgb21"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#7efffd7fd42d85a1062f45799c3ca28a58438ec4"
+source = "git+https://github.com/rgb-org/rgb-core#41f23e3625bc6671bc804ed6ad085f7304e6ed17"
 dependencies = [
  "amplify",
  "amplify_derive",
  "bitcoin",
  "chrono",
  "lnpbp",
- "rgb-core",
+ "rgb-core 0.4.0 (git+https://github.com/rgb-org/rgb-core)",
 ]
 
 [[package]]
 name = "rgb22"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#7efffd7fd42d85a1062f45799c3ca28a58438ec4"
+source = "git+https://github.com/rgb-org/rgb-core#41f23e3625bc6671bc804ed6ad085f7304e6ed17"
 dependencies = [
  "amplify",
  "amplify_derive",
  "bitcoin",
  "chrono",
  "lnpbp",
- "rgb-core",
+ "rgb-core 0.4.0 (git+https://github.com/rgb-org/rgb-core)",
 ]
 
 [[package]]
 name = "rgb23"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#7efffd7fd42d85a1062f45799c3ca28a58438ec4"
+source = "git+https://github.com/rgb-org/rgb-core#41f23e3625bc6671bc804ed6ad085f7304e6ed17"
 dependencies = [
  "amplify",
  "amplify_derive",
  "bitcoin",
  "chrono",
  "lnpbp",
- "rgb-core",
+ "rgb-core 0.4.0 (git+https://github.com/rgb-org/rgb-core)",
 ]
 
 [[package]]
@@ -1684,7 +1717,7 @@ dependencies = [
  "log",
  "microservices",
  "nix",
- "rgb-core",
+ "rgb-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rgb20",
  "rgb21",
  "rgb22",
@@ -1833,7 +1866,7 @@ checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -1886,7 +1919,7 @@ dependencies = [
  "darling",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -2020,7 +2053,7 @@ dependencies = [
  "amplify",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -2070,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123a78a3596b24fee53a6464ce52d8ecbf62241e6294c7e7fe12086cd161f512"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -2099,7 +2132,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
  "unicode-xid 0.2.1",
 ]
 
@@ -2119,15 +2152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]
@@ -2216,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "unicode-bidi"
@@ -2350,7 +2374,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
  "wasm-bindgen-shared",
 ]
 
@@ -2372,7 +2396,7 @@ checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2512,7 +2536,7 @@ checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.62",
+ "syn 1.0.64",
  "synstructure 0.12.4",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ required-features = ["cli"]
 amplify = "3"
 amplify_derive = "2.4.2"
 lnpbp = "0.4"
-rgb-core = { git = "https://github.com/rgb-org/rgb-core" }
+rgb-core = "0.4"
 descriptor-wallet = { version = "0.4", features = ["electrum"] }
-rgb20 = { git = "https://github.com/rgb-org/rgb-core", optional = true }
+rgb20 = { version = "0.4", optional = true }
 rgb21 = { git = "https://github.com/rgb-org/rgb-core", optional = true }
 rgb22 = { git = "https://github.com/rgb-org/rgb-core", optional = true }
 rgb23 = { git = "https://github.com/rgb-org/rgb-core", optional = true }

--- a/src/cli/fungible.rs
+++ b/src/cli/fungible.rs
@@ -88,6 +88,12 @@ pub enum Command {
         blinding_factor: u64,
     },
 
+    /// Adds data from some disclosure to the stash & asset information cache
+    Enclose {
+        /// Path to disclosure file
+        disclosure: PathBuf,
+    },
+
     Forget {
         /// Bitcoin transaction output that was spent and which data
         /// has to be forgotten
@@ -119,11 +125,16 @@ pub struct TransferCli {
     /// Read partially-signed transaction prototype
     pub prototype: PathBuf,
 
-    /// File to save consignment to. It will produce two files:
-    /// - one with concealed data to share with the receiver, having extension
-    ///   `.concealed.rgb`, and
-    /// - one with plain complete data, having extension `.revealed.rgb`
+    /// File to save consignment to
     pub consignment: PathBuf,
+
+    /// File to save disclosure to.
+    ///
+    /// Disclosures are used to allocate the change and other assets which were
+    /// on the same output but were not transferred. To see the change and
+    /// those assets you will have to accept disclosure lately with special
+    /// `enclose` command.
+    pub disclosure: PathBuf,
 
     /// File to save updated partially-signed bitcoin transaction to
     pub transaction: PathBuf,
@@ -163,6 +174,9 @@ impl Command {
                 outpoint,
                 blinding_factor,
             ),
+            Command::Enclose { ref disclosure } => {
+                self.exec_enclose(runtime, disclosure.clone())
+            }
             Command::Forget { outpoint } => self.exec_forget(runtime, outpoint),
         }
     }
@@ -336,7 +350,10 @@ impl Command {
             if outpoint_reveal.commit_conceal()
                 != seal_endpoint.commit_conceal()
             {
-                eprintln!("The provided outpoint and blinding factors does not match outpoint from the consignment");
+                eprintln!(
+                    "The provided outpoint and blinding factors does not match \
+                    outpoint from the consignment"
+                );
                 Err(Error::DataInconsistency)?
             }
             AcceptReq {
@@ -344,7 +361,11 @@ impl Command {
                 reveal_outpoints: vec![outpoint_reveal],
             }
         } else {
-            eprintln!("Currently, this command-line tool is unable to accept consignments containing more than a single locally-controlled output point");
+            eprintln!(
+                "Currently, this command-line tool is unable to accept \
+                consignments containing more than a single locally-controlled \
+                output point"
+            );
             Err(Error::UnsupportedFunctionality)?
         };
 
@@ -358,6 +379,41 @@ impl Command {
             _ => {
                 eprintln!(
                     "Unexpected server error; probably you connecting with outdated client version"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn exec_enclose(
+        &self,
+        mut runtime: Runtime,
+        filename: PathBuf,
+    ) -> Result<(), Error> {
+        info!("Enclosing disclosure...");
+
+        debug!("Reading disclosure from file {:?}", &filename);
+        let disclosure =
+            Disclosure::read_file(filename.clone()).map_err(|err| {
+                Error::InputFileFormatError(
+                    format!("{:?}", filename),
+                    format!("{}", err),
+                )
+            })?;
+        trace!("{:#?}", disclosure);
+
+        match &*runtime.enclose(disclosure)? {
+            Reply::Failure(failure) => {
+                eprintln!("Server returned error: {}", failure);
+            }
+            Reply::Success => {
+                eprintln!("Disclosure data successfully enclosed.");
+            }
+            _ => {
+                eprintln!(
+                    "Unexpected server error; probably you connecting with \
+                    outdated client version"
                 );
             }
         }

--- a/src/cli/fungible.rs
+++ b/src/cli/fungible.rs
@@ -549,22 +549,8 @@ impl TransferCli {
                 eprintln!("Transfer failed: {}", failure);
             }
             Reply::Transfer(transfer) => {
-                let mut consignment = transfer.consignment.clone();
                 transfer.disclosure.write_file(&self.disclosure)?;
-
-                let receiver = self.receiver;
-                let expose = consignment
-                    .endpoints
-                    .iter()
-                    .filter_map(|(_, endpoint)| match endpoint {
-                        SealEndpoint::TxOutpoint(h) if *h == receiver => {
-                            Some(*endpoint)
-                        }
-                        _ => None,
-                    })
-                    .collect();
-                consignment.finalize(&expose, self.asset);
-                consignment.write_file(&self.consignment)?;
+                transfer.consignment.write_file(&self.consignment)?;
 
                 let out_file = fs::File::create(&self.transaction)
                     .expect("can't create output transaction file");
@@ -578,7 +564,7 @@ impl TransferCli {
                     self.consignment, self.disclosure, self.transaction
                 );
                 eprint!("Consignment data to share:");
-                println!("{}", consignment);
+                println!("{}", transfer.consignment);
             }
             _ => (),
         }

--- a/src/cli/fungible.rs
+++ b/src/cli/fungible.rs
@@ -27,7 +27,7 @@ use rgb::prelude::*;
 use rgb20::{Asset, SealCoins};
 
 use super::{Error, OutputFormat, Runtime};
-use crate::rpc::fungible::{AcceptApi, Issue, TransferApi};
+use crate::rpc::fungible::{AcceptReq, IssueReq, TransferReq};
 use crate::rpc::{reply, Reply};
 use crate::util::file::ReadWrite;
 
@@ -58,7 +58,7 @@ pub enum Command {
     },
 
     /// Creates a new asset
-    Issue(Issue),
+    Issue(IssueReq),
 
     /// Creates a blinded version of a given bitcoin transaction outpoint
     Blind {
@@ -339,7 +339,7 @@ impl Command {
                 eprintln!("The provided outpoint and blinding factors does not match outpoint from the consignment");
                 Err(Error::DataInconsistency)?
             }
-            AcceptApi {
+            AcceptReq {
                 consignment,
                 reveal_outpoints: vec![outpoint_reveal],
             }
@@ -392,7 +392,7 @@ impl Command {
     }
 }
 
-impl Issue {
+impl IssueReq {
     pub fn exec(self, mut runtime: Runtime) -> Result<(), Error> {
         info!("Issuing asset ...");
         debug!("{}", self.clone());
@@ -472,7 +472,7 @@ impl TransferCli {
         }
         trace!("{:?}", psbt);
 
-        let api = TransferApi {
+        let api = TransferReq {
             witness: psbt,
             contract_id: self.asset,
             inputs: self.inputs.into_iter().collect(),

--- a/src/cli/fungible.rs
+++ b/src/cli/fungible.rs
@@ -550,11 +550,7 @@ impl TransferCli {
             }
             Reply::Transfer(transfer) => {
                 let mut consignment = transfer.consignment.clone();
-                let mut theirs = self.consignment.clone();
-                theirs.set_extension("concealed.rgb");
-                let mut ours = self.consignment;
-                ours.set_extension("revealed.rgb");
-                consignment.write_file(&ours)?;
+                transfer.disclosure.write_file(&self.disclosure)?;
 
                 let receiver = self.receiver;
                 let expose = consignment
@@ -568,7 +564,7 @@ impl TransferCli {
                     })
                     .collect();
                 consignment.finalize(&expose, self.asset);
-                consignment.write_file(&theirs)?;
+                consignment.write_file(&self.consignment)?;
 
                 let out_file = fs::File::create(&self.transaction)
                     .expect("can't create output transaction file");
@@ -577,9 +573,9 @@ impl TransferCli {
                 })?;
 
                 eprintln!(
-                    "Transfer succeeded, consignments are written to {:?} and {:?}, \
-                     partially signed witness transaction to {:?}",
-                    theirs, ours, self.transaction
+                    "Transfer succeeded, consignments and disclosure are written \
+                     to {:?} and {:?}, partially signed witness transaction to {:?}",
+                    self.consignment, self.disclosure, self.transaction
                 );
                 eprint!("Consignment data to share:");
                 println!("{}", consignment);

--- a/src/cli/runtime.rs
+++ b/src/cli/runtime.rs
@@ -19,7 +19,7 @@ use internet2::{
     session, transport, CreateUnmarshaller, PlainTranscoder, Session,
     TypedEnum, Unmarshall, Unmarshaller,
 };
-use rgb::{Consignment, ContractId, Genesis, SchemaId};
+use rgb::{Consignment, ContractId, Disclosure, Genesis, SchemaId};
 
 use super::{Config, Error};
 use crate::cli::OutputFormat;
@@ -154,6 +154,14 @@ impl Runtime {
     #[inline]
     pub fn accept(&mut self, accept: AcceptReq) -> Result<Arc<Reply>, Error> {
         Ok(self.fungible_command(fungible::Request::Accept(accept))?)
+    }
+
+    #[inline]
+    pub fn enclose(
+        &mut self,
+        disclosure: Disclosure,
+    ) -> Result<Arc<Reply>, Error> {
+        Ok(self.fungible_command(fungible::Request::Enclose(disclosure))?)
     }
 
     #[inline]

--- a/src/cli/runtime.rs
+++ b/src/cli/runtime.rs
@@ -24,7 +24,7 @@ use rgb::{Consignment, ContractId, Genesis, SchemaId};
 use super::{Config, Error};
 use crate::cli::OutputFormat;
 use crate::error::{BootstrapError, ServiceErrorDomain};
-use crate::rpc::fungible::{self, AcceptApi, Issue, TransferApi};
+use crate::rpc::fungible::{self, AcceptReq, IssueReq, TransferReq};
 use crate::rpc::stash;
 use crate::rpc::Reply;
 use microservices::FileFormat;
@@ -131,14 +131,14 @@ impl Runtime {
     }
 
     #[inline]
-    pub fn issue(&mut self, issue: Issue) -> Result<Arc<Reply>, Error> {
+    pub fn issue(&mut self, issue: IssueReq) -> Result<Arc<Reply>, Error> {
         Ok(self.fungible_command(fungible::Request::Issue(issue))?)
     }
 
     #[inline]
     pub fn transfer(
         &mut self,
-        transfer: TransferApi,
+        transfer: TransferReq,
     ) -> Result<Arc<Reply>, Error> {
         Ok(self.fungible_command(fungible::Request::Transfer(transfer))?)
     }
@@ -152,7 +152,7 @@ impl Runtime {
     }
 
     #[inline]
-    pub fn accept(&mut self, accept: AcceptApi) -> Result<Arc<Reply>, Error> {
+    pub fn accept(&mut self, accept: AcceptReq) -> Result<Arc<Reply>, Error> {
         Ok(self.fungible_command(fungible::Request::Accept(accept))?)
     }
 

--- a/src/fungibled/runtime.rs
+++ b/src/fungibled/runtime.rs
@@ -43,7 +43,7 @@ use crate::rpc::{
     self,
     fungible::{AcceptApi, Issue, Request, TransferApi},
     reply,
-    stash::MergeRequest,
+    stash::AcceptRequest,
     stash::TransferRequest,
     Reply,
 };
@@ -446,7 +446,7 @@ impl Runtime {
         accept: AcceptApi,
     ) -> Result<Reply, ServiceErrorDomain> {
         let reply =
-            self.stash_req_rep(rpc::stash::Request::Merge(MergeRequest {
+            self.stash_req_rep(rpc::stash::Request::Accept(AcceptRequest {
                 consignment: accept.consignment.clone(),
                 reveal_outpoints: accept.reveal_outpoints.clone(),
             }))?;

--- a/src/fungibled/runtime.rs
+++ b/src/fungibled/runtime.rs
@@ -420,7 +420,7 @@ impl Runtime {
         consign_req: TransferRequest,
     ) -> Result<Reply, ServiceErrorDomain> {
         let reply =
-            self.stash_req_rep(rpc::stash::Request::Consign(consign_req))?;
+            self.stash_req_rep(rpc::stash::Request::Transfer(consign_req))?;
         if let Reply::Transfer(_) = reply {
             Ok(reply)
         } else {

--- a/src/i9n/fungible.rs
+++ b/src/i9n/fungible.rs
@@ -31,8 +31,8 @@ use super::{Error, Runtime};
 use crate::error::ServiceErrorDomain;
 use crate::rpc::reply::Transfer;
 use crate::rpc::{
-    fungible::AcceptApi, fungible::Issue, fungible::Request,
-    fungible::TransferApi, reply, Reply,
+    fungible::AcceptReq, fungible::IssueReq, fungible::Request,
+    fungible::TransferReq, reply, Reply,
 };
 
 impl Runtime {
@@ -62,7 +62,7 @@ impl Runtime {
         if self.config.network != chain {
             Err(Error::WrongNetwork)?;
         }
-        let command = Request::Issue(Issue {
+        let command = Request::Issue(IssueReq {
             ticker,
             name,
             description,
@@ -111,7 +111,7 @@ impl Runtime {
         }
         trace!("{:?}", witness);
 
-        let api = TransferApi {
+        let api = TransferReq {
             witness,
             contract_id,
             inputs,
@@ -135,7 +135,7 @@ impl Runtime {
         consignment: Consignment,
         reveal_outpoints: Vec<OutpointReveal>,
     ) -> Result<(), Error> {
-        let api = AcceptApi {
+        let api = AcceptReq {
             consignment,
             reveal_outpoints,
         };

--- a/src/i9n/fungible.rs
+++ b/src/i9n/fungible.rs
@@ -22,7 +22,7 @@ use lnpbp::seals::OutpointReveal;
 use lnpbp::Chain;
 use microservices::FileFormat;
 use rgb::{
-    AtomicValue, Consignment, ContractId, Genesis, SealDefinition,
+    AtomicValue, Consignment, ContractId, Disclosure, Genesis, SealDefinition,
     SealEndpoint, PSBT_OUT_PUBKEY,
 };
 use rgb20::{Asset, OutpointCoins};
@@ -159,6 +159,17 @@ impl Runtime {
             Reply::ValidationStatus(status) => {
                 info!("Validation succeeded");
                 Ok(status.clone())
+            }
+            _ => Err(Error::UnexpectedResponse),
+        }
+    }
+
+    pub fn enclose(&mut self, disclosure: Disclosure) -> Result<(), Error> {
+        match &*self.command(Request::Enclose(disclosure))? {
+            Reply::Failure(failure) => Err(Error::Reply(failure.clone())),
+            Reply::Success => {
+                info!("Enclose command succeeded");
+                Ok(())
             }
             _ => Err(Error::UnexpectedResponse),
         }

--- a/src/rpc/fungible.rs
+++ b/src/rpc/fungible.rs
@@ -18,7 +18,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::OutPoint;
 use lnpbp::seals::OutpointReveal;
-use rgb::{AtomicValue, Consignment, ContractId, SealDefinition, SealEndpoint};
+use rgb::{
+    AtomicValue, Consignment, ContractId, Disclosure, Genesis, SealDefinition,
+    SealEndpoint,
+};
 use rgb20::OutpointCoins;
 
 use microservices::FileFormat;
@@ -30,29 +33,33 @@ use microservices::FileFormat;
 #[non_exhaustive]
 pub enum Request {
     #[api(type = 0x0101)]
-    Issue(crate::rpc::fungible::Issue),
+    Issue(IssueReq),
 
     #[api(type = 0x0103)]
-    Transfer(crate::rpc::fungible::TransferApi),
+    Transfer(TransferReq),
 
     #[api(type = 0x0105)]
     #[display("validate(...)")]
-    Validate(::rgb::Consignment),
+    Validate(Consignment),
 
     #[api(type = 0x0107)]
-    Accept(crate::rpc::fungible::AcceptApi),
+    Accept(AcceptReq),
+
+    #[api(type = 0x0108)]
+    #[display("enclose({0})")]
+    Enclose(Disclosure),
 
     #[api(type = 0x0109)]
     #[display("import_asset({0})")]
-    ImportAsset(::rgb::Genesis),
+    ImportAsset(Genesis),
 
     #[api(type = 0x010b)]
     #[display("export_asset({0})")]
-    ExportAsset(::rgb::ContractId),
+    ExportAsset(ContractId),
 
     #[api(type = 0x010d)]
     #[display("forget({0})")]
-    Forget(::bitcoin::OutPoint),
+    Forget(OutPoint),
 
     #[api(type = 0xFF01)]
     #[display("sync(using: {0})")]
@@ -77,7 +84,7 @@ pub enum Request {
     derive(Serialize, Deserialize,),
     serde(crate = "serde_crate")
 )]
-pub struct Issue {
+pub struct IssueReq {
     /// Asset ticker (up to 8 characters, always converted to uppercase)
     #[clap(validator=ticker_validator)]
     pub ticker: String,
@@ -116,7 +123,7 @@ pub struct Issue {
 #[derive(Clone, PartialEq, StrictEncode, StrictDecode, Debug, Display)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("transfer({contract_id}, ...)")]
-pub struct TransferApi {
+pub struct TransferReq {
     /// Asset contract id
     pub contract_id: ContractId,
 
@@ -142,7 +149,7 @@ pub struct TransferApi {
 #[derive(Clone, StrictEncode, StrictDecode, Debug, Display)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("accept(...)")]
-pub struct AcceptApi {
+pub struct AcceptReq {
     /// Raw consignment data
     pub consignment: Consignment,
 

--- a/src/rpc/reply.rs
+++ b/src/rpc/reply.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::OutPoint;
 use microservices::FileFormat;
-use rgb::{AtomicValue, Consignment, ContractId};
+use rgb::{AtomicValue, Consignment, ContractId, Disclosure};
 use rgb20::Asset;
 
 #[cfg(feature = "node")]
@@ -121,6 +121,7 @@ pub struct SyncFormat(pub FileFormat, pub Vec<u8>);
 #[display("transfer(...)")]
 pub struct Transfer {
     pub consignment: Consignment,
+    pub disclosure: Disclosure,
     pub witness: Psbt,
 }
 

--- a/src/rpc/stash.rs
+++ b/src/rpc/stash.rs
@@ -16,7 +16,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::OutPoint;
 use lnpbp::seals::OutpointReveal;
-use rgb::{Consignment, ContractId, SealEndpoint, Transition};
+use rgb::{
+    Consignment, ContractId, Disclosure, Genesis, NodeId, Schema, SchemaId,
+    SealEndpoint, Transition,
+};
 
 #[derive(Clone, Debug, Display, Api)]
 #[api(encoding = "strict")]
@@ -26,7 +29,7 @@ use rgb::{Consignment, ContractId, SealEndpoint, Transition};
 pub enum Request {
     #[api(type = 0x0101)]
     #[display("add_schema({0})")]
-    AddSchema(::rgb::Schema),
+    AddSchema(Schema),
 
     #[api(type = 0x0103)]
     #[display("list_schemata()")]
@@ -34,11 +37,11 @@ pub enum Request {
 
     #[api(type = 0x0105)]
     #[display("read_schema({0})")]
-    ReadSchema(::rgb::SchemaId),
+    ReadSchema(SchemaId),
 
     #[api(type = 0x0201)]
     #[display("add_genesis({0})")]
-    AddGenesis(::rgb::Genesis),
+    AddGenesis(Genesis),
 
     #[api(type = 0x0203)]
     #[display("list_geneses()")]
@@ -46,24 +49,29 @@ pub enum Request {
 
     #[api(type = 0x0205)]
     #[display("read_genesis({0})")]
-    ReadGenesis(::rgb::ContractId),
+    ReadGenesis(ContractId),
 
     #[api(type = 0x0301)]
     #[display("read_transitions(...)")]
-    ReadTransitions(Vec<::rgb::NodeId>),
+    ReadTransitions(Vec<NodeId>),
 
     #[api(type = 0x0401)]
-    Transfer(crate::rpc::stash::TransferRequest),
+    Transfer(TransferRequest),
 
     #[api(type = 0x0403)]
-    Validate(::rgb::Consignment),
+    #[display("validate({0})")]
+    Validate(Consignment),
 
     #[api(type = 0x0405)]
-    Merge(crate::rpc::stash::MergeRequest),
+    Accept(AcceptRequest),
+
+    #[api(type = 0x0406)]
+    #[display("enclose({0})")]
+    Enclose(Disclosure),
 
     #[api(type = 0x0407)]
     #[display("forget(...)")]
-    Forget(Vec<(::rgb::NodeId, u16)>),
+    Forget(Vec<(NodeId, u16)>),
 }
 
 #[derive(Clone, StrictEncode, StrictDecode, Debug, Display)]
@@ -80,8 +88,8 @@ pub struct TransferRequest {
 
 #[derive(Clone, StrictEncode, StrictDecode, Debug, Display)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
-#[display("merge(...)")]
-pub struct MergeRequest {
+#[display("accept(...)")]
+pub struct AcceptRequest {
     pub consignment: Consignment,
     pub reveal_outpoints: Vec<OutpointReveal>,
 }

--- a/src/rpc/stash.rs
+++ b/src/rpc/stash.rs
@@ -53,7 +53,7 @@ pub enum Request {
     ReadTransitions(Vec<::rgb::NodeId>),
 
     #[api(type = 0x0401)]
-    Consign(crate::rpc::stash::TransferRequest),
+    Transfer(crate::rpc::stash::TransferRequest),
 
     #[api(type = 0x0403)]
     Validate(::rgb::Consignment),

--- a/src/rpc/stash.rs
+++ b/src/rpc/stash.rs
@@ -16,7 +16,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::OutPoint;
 use lnpbp::seals::OutpointReveal;
-use rgb::{Consignment, ContractId, NodeId, SealEndpoint, Transition};
+use rgb::{Consignment, ContractId, SealEndpoint, Transition};
 
 #[derive(Clone, Debug, Display, Api)]
 #[api(encoding = "strict")]
@@ -53,7 +53,7 @@ pub enum Request {
     ReadTransitions(Vec<::rgb::NodeId>),
 
     #[api(type = 0x0401)]
-    Consign(crate::rpc::stash::ConsignRequest),
+    Consign(crate::rpc::stash::TransferRequest),
 
     #[api(type = 0x0403)]
     Validate(::rgb::Consignment),
@@ -69,11 +69,11 @@ pub enum Request {
 #[derive(Clone, StrictEncode, StrictDecode, Debug, Display)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("consign({contract_id}, ...)")]
-pub struct ConsignRequest {
+pub struct TransferRequest {
     pub contract_id: ContractId,
     pub inputs: BTreeSet<OutPoint>,
     pub transition: Transition,
-    pub other_transition_ids: BTreeMap<ContractId, NodeId>,
+    pub other_transitions: BTreeMap<ContractId, Transition>,
     pub endpoints: BTreeSet<SealEndpoint>,
     pub psbt: Psbt,
 }

--- a/src/stashd/runtime.rs
+++ b/src/stashd/runtime.rs
@@ -163,7 +163,7 @@ impl Runtime {
                 self.rpc_read_genesis(contract_id)
             }
             Request::ReadSchema(schema_id) => self.rpc_read_schema(schema_id),
-            Request::Consign(consign) => self.rpc_transfer(consign),
+            Request::Transfer(consign) => self.rpc_transfer(consign),
             Request::Validate(consign) => self.rpc_validate(consign),
             Request::Merge(merge) => self.rpc_merge(merge),
             Request::Forget(removal_list) => self.rpc_forget(removal_list),
@@ -223,13 +223,11 @@ impl Runtime {
         Ok(Reply::Schema(schema))
     }
 
-    // TODO: Rename into `transfer` (since it will produce both Consignment and
-    //       Disclosure)
     fn rpc_transfer(
         &mut self,
         request: &TransferRequest,
     ) -> Result<Reply, ServiceErrorDomain> {
-        debug!("Got CONSIGN {}", request);
+        debug!("Got TRANSFER {}", request);
 
         let mut transitions = request.other_transitions.clone();
         transitions.insert(request.contract_id, request.transition.clone());

--- a/src/stashd/runtime.rs
+++ b/src/stashd/runtime.rs
@@ -264,7 +264,7 @@ impl Runtime {
 
         Ok(Reply::Transfer(reply::Transfer {
             consignment,
-            disclosure: Disclosure {},
+            disclosure: Disclosure::default(),
             witness: psbt,
         }))
     }
@@ -297,7 +297,7 @@ impl Runtime {
         let known_seals = &merge.reveal_outpoints;
         let consignment = &merge.consignment;
 
-        self.merge(consignment, known_seals)
+        self.accept(consignment, known_seals)
             .map_err(|_| ServiceErrorDomain::Stash)?;
 
         Ok(Reply::Success)

--- a/src/stashd/stash.rs
+++ b/src/stashd/stash.rs
@@ -17,8 +17,8 @@ use bitcoin::hashes::Hash;
 use lnpbp::seals::OutpointReveal;
 use rgb::{
     Anchor, Assignments, ConcealState, Consignment, ContractId, Disclosure,
-    Extension, Genesis, Node, NodeId, SchemaId, SealEndpoint, Stash,
-    Transition,
+    Extension, Genesis, IntoRevealed, Node, NodeId, SchemaId, SealEndpoint,
+    Stash, Transition,
 };
 
 use super::index::Index;
@@ -26,17 +26,27 @@ use super::storage::Store;
 use super::Runtime;
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, From, Error)]
-#[display(Debug)]
+#[display(doc_comments)]
 pub enum Error {
+    /// Storage error
     #[from(super::storage::DiskStorageError)]
     StorageError,
 
+    /// Index error
     #[from(super::index::BTreeIndexError)]
     IndexError,
 
+    /// To create consignment for a state transition (state extension)
+    /// operation you have to provide anchor data
     AnchorParameterIsRequired,
 
+    /// You can't create consignments for pure genesis data; just share plain
+    /// genesis instead
     GenesisNode,
+
+    /// Trying to import data related to an unknown contract {0}. Please import
+    /// genesis for that contract first.
+    UnknownContract(ContractId),
 }
 
 pub struct DumbIter<T>(std::marker::PhantomData<T>);
@@ -232,6 +242,7 @@ impl Stash for Runtime {
                 .owned_rights_mut()
                 .into_iter()
                 .for_each(reveal_known_seals);
+            let anchor = anchor.clone();
             // Store the transition and the anchor data in the stash
             self.storage.add_anchor(&anchor)?;
             // TODO: Uncomment once indexing will be implemented
@@ -251,11 +262,69 @@ impl Stash for Runtime {
         Ok(())
     }
 
+    // TODO: Rename into `enclose`
     fn know_about(
         &mut self,
         disclosure: Disclosure,
     ) -> Result<(), Self::Error> {
-        unimplemented!()
+        // Do a disclosure verification: check that we know contract_ids
+        let contract_ids = disclosure
+            .transitions()
+            .values()
+            .map(|(_, map)| map.keys())
+            .flatten()
+            .chain(disclosure.extensions().keys())
+            .copied()
+            .collect::<BTreeSet<_>>();
+        for contract_id in contract_ids {
+            let _ = self
+                .storage
+                .genesis(&contract_id)
+                .map_err(|_| Error::UnknownContract(contract_id))?;
+        }
+
+        for anchor in
+            disclosure.transitions().values().map(|(anchor, _)| anchor)
+        {
+            let mut anchor: Anchor = anchor.clone();
+            if let Ok(other_anchor) = self.storage.anchor(&anchor.anchor_id()) {
+                anchor = anchor
+                    .into_revealed(other_anchor)
+                    .expect("RGB commitment procedure is broken");
+            }
+            self.storage.add_anchor(&anchor)?;
+        }
+
+        for transition in disclosure
+            .transitions()
+            .values()
+            .map(|(_, map)| map.values())
+            .flatten()
+        {
+            let mut transition: Transition = transition.clone();
+            if let Ok(other_transition) =
+                self.storage.transition(&transition.node_id())
+            {
+                transition = transition
+                    .into_revealed(other_transition)
+                    .expect("RGB commitment procedure is broken");
+            }
+            self.storage.add_transition(&transition)?;
+        }
+
+        for extension in disclosure.extensions().values().flatten() {
+            let mut extension: Extension = extension.clone();
+            if let Ok(other_extension) =
+                self.storage.extension(&extension.node_id())
+            {
+                extension = extension
+                    .into_revealed(other_extension)
+                    .expect("RGB commitment procedure is broken");
+            }
+            self.storage.add_extension(&extension)?;
+        }
+
+        Ok(())
     }
 
     fn forget(

--- a/src/stashd/stash.rs
+++ b/src/stashd/stash.rs
@@ -193,7 +193,7 @@ impl Stash for Runtime {
         ))
     }
 
-    fn merge(
+    fn accept(
         &mut self,
         consignment: &Consignment,
         known_seals: &Vec<OutpointReveal>,
@@ -251,6 +251,13 @@ impl Stash for Runtime {
         Ok(())
     }
 
+    fn know_about(
+        &mut self,
+        disclosure: Disclosure,
+    ) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+
     fn forget(
         &mut self,
         _consignment: Consignment,
@@ -259,10 +266,6 @@ impl Stash for Runtime {
     }
 
     fn prune(&mut self) -> Result<usize, Self::Error> {
-        unimplemented!()
-    }
-
-    fn disclose(&self) -> Result<Disclosure, Self::Error> {
         unimplemented!()
     }
 }

--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -239,3 +239,31 @@ impl ReadWrite for Consignment {
         self.strict_encode(file)
     }
 }
+
+impl ReadWrite for Disclosure {
+    fn read_file(filename: impl AsRef<Path>) -> Result<Self, Error> {
+        let mut file = file(filename, FileMode::Read)?;
+        let mut magic_buf = [0u8; 4];
+        file.read_exact(&mut magic_buf)?;
+        let magic = u32::from_be_bytes(magic_buf);
+        let magic = MagicNumber::try_from(magic).map_err(|detected| {
+            Error::DataIntegrityError(format!(
+                "Wrong file type: expected consignment file, got unknown magic number {}",
+                detected
+            ))
+        })?;
+        if magic != MagicNumber::Disclosure {
+            Err(Error::DataIntegrityError(format!(
+                "Wrong file type: expected consignment file, got {}",
+                magic
+            )))?
+        }
+        Disclosure::strict_decode(file)
+    }
+
+    fn write_file(&self, filename: impl AsRef<Path>) -> Result<usize, Error> {
+        let mut file = file(filename, FileMode::Create)?;
+        file.write(&MagicNumber::Disclosure.to_u32().to_be_bytes())?;
+        self.strict_encode(file)
+    }
+}

--- a/src/util/magic_numbers.rs
+++ b/src/util/magic_numbers.rs
@@ -24,6 +24,7 @@ use core::convert::TryFrom;
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Display)]
 #[display(Debug)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum MagicNumber {
     /// Equals to first 4 bytes of SHA256("rgb:schema")
     /// = 18429ce35af7f898f765417b28471ab454b89ceff6fc33de77ff5fd98e066bc3
@@ -50,6 +51,10 @@ pub enum MagicNumber {
     /// = 4c82bf5385ab9027f15f1ce17a8007956fe8f38cbad2ee312cf2c55b72a69420
     Consignment = 0x4c82bf53,
 
+    /// Equals to first 4 bytes of SHA256("rgb:disclosure")
+    /// = e2fde682700fcef51e2dd3ef8e1c76340881e3ddfd81e9c45c54cf92b5b9483f
+    Disclosure = 0xe2fde682,
+
     /// Equals to first 4 bytes of SHA256("rgb:stash")
     /// = cd22a2cb85720d51f1616752cb85059a02f3d35f7dda30a4ca981b59b0924354
     Stash = 0xcd22a2cb,
@@ -75,6 +80,7 @@ impl TryFrom<u32> for MagicNumber {
             n if n == Self::Transition.to_u32() => Self::Transition,
             n if n == Self::Anchor.to_u32() => Self::Anchor,
             n if n == Self::Consignment.to_u32() => Self::Consignment,
+            n if n == Self::Disclosure.to_u32() => Self::Disclosure,
             n if n == Self::Stash.to_u32() => Self::Stash,
             invalid => Err(invalid)?,
         })


### PR DESCRIPTION
Depends on https://github.com/rgb-org/rgb-core/pull/26

Underlying logic of RGB Core and stash in RGB Node implies possibility to spend outputs containing multiple assets (or different forms of state) under multiple RGB smart contracts. However current implementation of Fungible daemon missed that part, that will lead to the loss of other assets if at least one of them is moved. This PR completes this logic; unfortunately it requires implementation of `Disclosures`, since otherwise it will be impossible to accept the other assets by the sender as a "change" (consignment can't contain information about more than a single RGB asset/contract).

Future work: 
1) this PR covers only RGB20 asset transfer; for other types of state (including non-RGB) another PRs will be required at the stash daemon level which must use `create_blank_transition` API from RGB virtual machine (reserved for that purpose)
2) if the same output contains RGB20 asset AND other right under **the same** asset, we need to fail the procedure and ask user to construct a special `RightsSplit` transition before doing `Transfer` transition (see https://github.com/rgb-org/rgb-core/blob/master/rgb20/src/schema.rs#L262-L287). This feature must be implemented in the fungible daemon RPC API.
