### PR TITLE
Fixing lines of README because original not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ then run the following commands:
 
     git clone https://github.com/LNP-BP/rgb-node.git
     cd rgb-node
-    cargo build --release --bins
+    cargo install --locked --root . rgb_node --features all
 
 Now, to run the node you can execute
 
-    target/release/rgbd --data-dir ~/.rgb --bin-dir target/release -vvvv --contract fungible
+    ./bin/rgbd -vvvv -b ./bin -d ./data
 
 ### In docker
 


### PR DESCRIPTION
The original lines for build didn't work:

:~/projects/rust/rgb-node$ cargo build --release --bins
    Finished release [optimized] target(s) in 0.37s
:~/projects/rust/rgb-node$ target/release/rgbd --data-dir ~/.rgb --bin-dir target/release -vvvv --contract fungible
bash: target/release/rgbd: No such file or directory

So i switch to the demo 0.1 and used this:
./bin/rgbd -vvvv -b ./bin -d ./data0

And work without problem.
