### PR TITLE
Fix README instructions using cargo install and all-features for local source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ then run the following commands:
 
     git clone https://github.com/LNP-BP/rgb-node.git
     cd rgb-node
-    cargo build --release --bins
+    cargo install --all-features --bins --path .
 
 Now, to run the node you can execute
 
-    target/release/rgbd --data-dir ~/.rgb --bin-dir target/release -vvvv --contract fungible
+    rgbd --data-dir ~/.rgb --bin-dir ~/.cargo/bin -vvvv --contract fungible
 
 ### In docker
 
@@ -126,9 +126,9 @@ docker run --rm --name rgb_node rgb-node
 ## Using
 
 First, you need to start daemons:
-`rgbd -vvvv -d <data_dir> -b <bin_dir>, --contract fungible`
+`rgbd -vvvv -d <data_dir> -b <bin_dir> --contract fungible`
 where `bin_dir` is a directory with all daemons binaries (usually
-`target/release` from repo source after `cargo build --release --bins`
+`~/.cargo/bin` from repo source after `cargo install --all-features --bins --path .`
 command).
 
 Issuing token:


### PR DESCRIPTION
The issue #170 intends to fix is valid, but I think a better approach was needed.

I made sure local source was used when installing. I think it's best we use install instead of pointing to the local target.

Also, I'm not 100% sure if we should also include a `--force` flag to the install command. If it's ever an issue in future releases, we might want that. Let me know if you'd like me to add it.