### PR TITLE
Add --features option to generate binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR "$SRC_DIR"
 COPY src src
 COPY Cargo.lock Cargo.toml README.md ./
 
-RUN cargo install --path . --root "${BUILDER_DIR}"
+RUN cargo install --path . --root "${BUILDER_DIR}" --features all
 
 
 FROM debian:buster-slim

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ then run the following commands:
 
     git clone https://github.com/LNP-BP/rgb-node.git
     cd rgb-node
-    cargo build --release --bins
+    cargo build --release --bins --features all
 
 Now, to run the node you can execute
 
@@ -128,7 +128,7 @@ docker run --rm --name rgb_node rgb-node
 First, you need to start daemons:
 `rgbd -vvvv -d <data_dir> -b <bin_dir>, --contract fungible`
 where `bin_dir` is a directory with all daemons binaries (usually
-`target/release` from repo source after `cargo build --release --bins`
+`target/release` from repo source after `cargo build --release --bins --features all`
 command).
 
 Issuing token:


### PR DESCRIPTION
The binary will not be generated unless the `--features` option is given, so the option description has been added.